### PR TITLE
Increase speed on repeated compiles by about 999 %

### DIFF
--- a/src/main/kotlin/compiler/Compiler.kt
+++ b/src/main/kotlin/compiler/Compiler.kt
@@ -255,9 +255,9 @@ object Compiler {
         return false
     }
 
+    val czechtina = czechtinaLesana()
     fun compileText(text:String): String {
         val preprocesed = compiler.Preprocessor.preprocessText(text, "")
-        val czechtina = czechtinaLesana()
         isParsed = false
         var tree: ASTProgramNode?
         var cCode = ""


### PR DESCRIPTION
Při každém průběhu kompilátoru se nemusí lesana znovu sestavovat, je to celkem náročný proces. Stačí jedna instance.
Na těch 7 napsaných testech se doba testování snížila z 2,3 na 0,9 s